### PR TITLE
Changed ResponseHelper so it cannot be missused with other http statu…

### DIFF
--- a/src/Collector.Common.RestApi.AspNet/Collector.Common.RestApi.AspNet.csproj
+++ b/src/Collector.Common.RestApi.AspNet/Collector.Common.RestApi.AspNet.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net45</TargetFrameworks>
 		<AssemblyName>Collector.Common.RestApi.AspNet</AssemblyName>
 		<PackageId>Collector.Common.RestApi.AspNet</PackageId>
-		<Version>8.0.1</Version>
+		<Version>9.0.0</Version>
 		<Description>WebApi filters, bindings, and utilities for request response logging, Collector.Common.RestContracts Model binding, Error handling and correlation</Description>
 		<Authors>Team Houdini, Team Heimdal</Authors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Collector.Common.RestApi.AspNet/Infrastructure/ResponseHelper.cs
+++ b/src/Collector.Common.RestApi.AspNet/Infrastructure/ResponseHelper.cs
@@ -7,15 +7,24 @@
 
     public static class ResponseHelper
     {
-        public static HttpResponseMessage BuildResponse<T>(this HttpRequestMessage request, T data, HttpStatusCode status = HttpStatusCode.OK, string apiVersion = null)
+        public static HttpResponseMessage BuildOkDataResponse<T>(this HttpRequestMessage request, T data)
         {
             var response = new Response<T>
             {
-                ApiVersion = apiVersion,
                 Data = data
             };
 
-            return request.CreateResponse(status, response);
+            return request.CreateResponse(HttpStatusCode.OK, response);
+        }
+
+        public static HttpResponseMessage BuildOkVoidResponse(this HttpRequestMessage request)
+        {
+            var response = new Response<object>
+            {
+                Data = null
+            };
+
+            return request.CreateResponse(HttpStatusCode.OK, response);
         }
     }
 }


### PR DESCRIPTION
…s codes than 200 (request.CreateResponse should be used in those cases) as well as created void version of build-method and renamed data method to reflect the distinction.